### PR TITLE
Add AMP compatibility and implement rendering on archive/home pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Enables MathML math formulas blocks in the editor.
 * Uses the MathJax library to render the formulas: https://www.mathjax.org
+* Compatible with the [official AMP plugin](https://amp-wp.org/) by rendering [`amp-mathml`](https://amp.dev/documentation/components/amp-mathml/) on [AMP pages](https://amp.dev/).
 
 ### What is MathML?
 

--- a/mathml-block.php
+++ b/mathml-block.php
@@ -14,7 +14,25 @@
  *
  * @package mathml-block
  */
+
 namespace MathMLBlock;
+
+use WP_Block_Type_Registry;
+
+const BLOCK_NAME = 'mathml/mathmlblock';
+
+/**
+ * Determine whether the response will be an AMP page.
+ *
+ * @return bool
+ */
+function is_amp() {
+	return (
+		( function_exists( 'amp_is_request' ) && \amp_is_request() )
+		||
+		( function_exists( 'is_amp_endpoint' ) && \is_amp_endpoint() )
+	);
+}
 
  /**
   * Enqueue the admin JavaScript assets.
@@ -52,13 +70,13 @@ add_action( 'init', __NAMESPACE__ . '\mathml_set_up_js_translations' );
 function potentially_add_front_end_mathjax_script() {
 	global $post;
 
-	// Only apply on singular pages.
-	if ( ! is_singular() ) {
+	// Only apply on singular pages which are not served as AMP.
+	if ( ! is_singular() || is_amp() ) {
 		return;
 	}
 
 	// Check the content for mathml blocks.
-	$has_mathml_block  = strpos( $post->post_content, 'wp:mathml/mathmlblock' );
+	$has_mathml_block  = strpos( $post->post_content, 'wp:' . BLOCK_NAME );
 	$has_mathml_inline = strpos( $post->post_content, '<mathml>' );
 	if ( false === $has_mathml_block && false === $has_mathml_inline ) {
 		return;
@@ -73,3 +91,72 @@ function potentially_add_front_end_mathjax_script() {
 
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\potentially_add_front_end_mathjax_script' );
+
+/**
+ * Register block.
+ */
+function register_block() {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
+	$registry = WP_Block_Type_Registry::get_instance();
+
+	// @todo This can probably be de-duplicated in the JS code with registerBlockType.
+	$attributes = array(
+		'formula' => array(
+			'source'   => 'html',
+			'selector' => 'div',
+			'type'     => 'string',
+		),
+	);
+
+	if ( $registry->is_registered( BLOCK_NAME ) ) {
+		$block                  = $registry->get_registered( BLOCK_NAME );
+		$block->render_callback = __NAMESPACE__ . '\render_block';
+		$block->attributes      = array_merge( $block->attributes, $attributes );
+	} else {
+		register_block_type(
+			BLOCK_NAME,
+			[
+				'render_callback' => __NAMESPACE__ . '\render_block',
+				'attributes'      => $attributes,
+			]
+		);
+	}
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Render block.
+ *
+ * Creates an <amp-mathml> element on AMP responses.
+ *
+ * @param array  $attributes Attributes.
+ * @param string $content    Content.
+ *
+ * @return string Rendered block.
+ */
+function render_block( $attributes, $content = '' ) {
+	if ( is_amp() && preg_match( '#^(?P<start_div>\s*<div.*?>)(?P<formula>.+)(?P<end_div></div>\s*)$#s', $content, $matches ) ) {
+		static $printed_style = false;
+		if ( ! $printed_style ) {
+			// Add same margins as .MJXc-display.
+			?>
+			<style class="amp-mathml">
+				.wp-block-mathml-mathmlblock amp-mathml { margin: 1em 0; }
+			</style>
+			<?php
+			$printed_style = true;
+		}
+
+		return sprintf(
+			'%s<amp-mathml layout="container" data-formula="%s"><span placeholder>%s</span></amp-mathml>%s',
+			$matches['start_div'],
+			esc_attr( $matches['formula'] ),
+			esc_html( $matches['formula'] ),
+			$matches['end_div']
+		);
+	}
+	return $content;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ To test a MathML block and enter a formula, for example: `\[x = {-b \pm \sqrt{b^
 
 To test using math formulas inline, type an formula into a block of text, select it and hit the 'M' icon in the control bar. For example: `\( \cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ) \)`. _Note: if you are copying and pasting formulas into the rich text editor, switching to HTML/code editor mode is less likely to reformat your pasted formula._
 
+This plugin is compatible with the [official AMP plugin](https://amp-wp.org/) by rendering [`amp-mathml`](https://amp.dev/documentation/components/amp-mathml/) on [AMP pages](https://amp.dev/).
+
 === Technical Notes ===
 
 * Requires PHP 5.4+.


### PR DESCRIPTION
Fixes #5.

This PR adds support for AMP by conditionally rendering `amp-mathml` on AMP pages. This will allow us to feature the plugin on the [amp-wp.org plugin ecosystem](https://amp-wp.org/ecosystem/plugins/) page, and we can move forward with deprecating the AMP MathML block in the AMP plugin (see https://github.com/ampproject/amp-wp/issues/4556).

Before | After
-------|-------
<img width="722" alt="Screen Shot 2020-09-15 at 09 53 18" src="https://user-images.githubusercontent.com/134745/93245964-e75fbc00-f740-11ea-8229-816b1293c22a.png"> | <img width="727" alt="Screen Shot 2020-09-15 at 10 16 56" src="https://user-images.githubusercontent.com/134745/93245967-e890e900-f740-11ea-8465-e825c3ec9ee8.png">

It also ensures that MathML blocks are rendered on archive pages, whereas previously they were only rendered on singular templates:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/93246127-2988fd80-f741-11ea-9482-6d00cab1ce7e.png) | ![image](https://user-images.githubusercontent.com/134745/93246195-445b7200-f741-11ea-9a62-02ebb8b0ea10.png)

Other changes:

* On non-AMP pages, the MathJax script is printed when the first MathML block is printed. This script is also printed with `async`. These two changes ensure no render blocking.
* Construction and registration of MathJax script URL is made more DRY.
* MathML block is registered server-side, though this can be further improved to reduce duplication in JS.

Some of the changes here are based on some learnings from the [Syntax-highlighting Code Block](https://github.com/westonruter/syntax-highlighting-code-block) plugin. For printing scripts and styles just-in-time with the rendering of blocks, see also https://github.com/WordPress/gutenberg/issues/21838#issuecomment-643657946.