### PR TITLE
Avoid printing style in block render_callback

### DIFF
--- a/mathml-block.php
+++ b/mathml-block.php
@@ -160,7 +160,7 @@ function render_block( $attributes, $content = '' ) {
 				.wp-block-mathml-mathmlblock amp-mathml { margin: 1em 0; }
 			</style>
 			<?php
-			$style = ob_get_clean();
+			$style         = ob_get_clean();
 			$printed_style = true;
 		}
 

--- a/mathml-block.php
+++ b/mathml-block.php
@@ -150,19 +150,24 @@ function render_block( $attributes, $content = '' ) {
 
 	if ( is_amp() ) {
 		static $printed_style = false;
+
+		$style = '';
 		if ( ! $printed_style ) {
 			// Add same margins as .MJXc-display.
+			ob_start();
 			?>
 			<style class="amp-mathml">
 				.wp-block-mathml-mathmlblock amp-mathml { margin: 1em 0; }
 			</style>
 			<?php
+			$style = ob_get_clean();
 			$printed_style = true;
 		}
 
 		return sprintf(
-			'%s<amp-mathml layout="container" data-formula="%s"><span placeholder>%s</span></amp-mathml>%s',
+			'%s%s<amp-mathml layout="container" data-formula="%s"><span placeholder>%s</span></amp-mathml>%s',
 			$matches['start_div'],
+			$style,
 			esc_attr( $matches['formula'] ),
 			esc_html( $matches['formula'] ),
 			$matches['end_div']


### PR DESCRIPTION
This is a follow up on #32.

I made a mistake in how I was adding the styles on AMP in that I was printing the styles in the block's `render_callback`. This causes a breakage in legacy Reader mode since `the_content` filters are applied before the templates are rendered:

Before | After
------|-------
<img width="412" alt="Screen Shot 2020-10-06 at 17 05 40" src="https://user-images.githubusercontent.com/134745/95272974-a9612f80-07f6-11eb-955f-bba2dc1de258.png"> | <img width="412" alt="Screen Shot 2020-10-06 at 17 06 08" src="https://user-images.githubusercontent.com/134745/95272980-abc38980-07f6-11eb-9390-3c55cdf70d87.png"> 
