### PR TITLE
fix markdown formatting for links in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -18,19 +18,23 @@ A MathML block for the WordPress block editor (Gutenberg).
 A MathML block for the WordPress block editor (Gutenberg).
 Requires PHP 5.4+ and WordPress 5.0+.
 
-Development takes place on the GitHub repository: https://github.com/adamsilverstein/mathml-block.
+Development takes place on the [GitHub repository](https://github.com/adamsilverstein/mathml-block).
 
-Screencast: https://cl.ly/c0f6bbfbc3b1
+Screencast: [https://cl.ly/c0f6bbfbc3b1](https://cl.ly/c0f6bbfbc3b1).
 
 === What is MathML? ===
 
 Mathematical Markup Language is a mathematical markup language, an application of XML for describing mathematical notations and capturing both its structure and content. It aims at integrating mathematical formulae into World Wide Web pages and other documents.
 
-The MathML block uses MathJax to render MathML formulas in the editor and on the front end of a website. MathJax (https://www.mathjax.org/) is _A JavaScript display engine for mathematics that works in all browsers._
+The MathML block uses MathJax to render MathML formulas in the editor and on the front end of a website. [MathJax](https://www.mathjax.org/) is _A JavaScript display engine for mathematics that works in all browsers._
 
-To test a MathML block and enter a formula, for example: `\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}\]`.
+To test a MathML block and enter a formula, for example:
+`\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}\]`
 
-To test using math formulas inline, type an formula into a block of text, select it and hit the 'M' icon in the control bar. For example: `\( \cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ) \)`. _Note: if you are copying and pasting formulas into the rich text editor, switching to HTML/code editor mode is less likely to reformat your pasted formula._
+To test using math formulas inline, type an formula into a block of text, select it and hit the 'M' icon in the control bar. For example:
+`\( \cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ) \)`
+
+_Note: if you are copying and pasting formulas into the rich text editor, switching to HTML/code editor mode is less likely to reformat your pasted formula._
 
 This plugin is compatible with the [official AMP plugin](https://amp-wp.org/) by rendering [`amp-mathml`](https://amp.dev/documentation/components/amp-mathml/) on [AMP pages](https://amp.dev/).
 
@@ -38,7 +42,7 @@ This plugin is compatible with the [official AMP plugin](https://amp-wp.org/) by
 
 * Requires PHP 5.6+.
 * Requires WordPress 5.0+.
-* Issues and Pull requests welcome on the GitHub repository: https://github.com/adamsilverstein/mathml-block.
+* Issues and Pull requests welcome on the [GitHub repository](https://github.com/adamsilverstein/mathml-block).
 
 == Screenshots ==
 


### PR DESCRIPTION
The links do not render on the dotorg plugin page: https://wordpress.org/plugins/mathml-block/.  This PR updates links to correct markdown format so they're clickable on the dotorg plugin page.

Note that another thing that would be nice is a second screenshot that shows how the formula is entered before its rendered.